### PR TITLE
fix:解决文本编辑区域底部滚动条异常显示及导出PDF内容下方出现滚动条图片的问题

### DIFF
--- a/mdmdt-dark.css
+++ b/mdmdt-dark.css
@@ -105,6 +105,7 @@ body content,
 body #write {
   scrollbar-width: thin !important;
   scrollbar-color: var(--text-grey) var(--bg-color2) !important;
+  overflow-x: auto;
 }
 
 body,
@@ -1638,6 +1639,14 @@ body.typora-export {
 }
 #top-titlebar .btn {
   margin: 0 !important;
+}
+
+#top-titlebar {
+  height: auto;
+}
+
+.info-panel-tab-wrapper {
+  height: auto;
 }
 
 /* .megamenu-men */

--- a/mdmdt-dark.css
+++ b/mdmdt-dark.css
@@ -105,7 +105,6 @@ body content,
 body #write {
   scrollbar-width: thin !important;
   scrollbar-color: var(--text-grey) var(--bg-color2) !important;
-  overflow-x: auto;
 }
 
 body,
@@ -856,7 +855,7 @@ span.md-comment {
   padding: 0 96px 32px;
   scroll-behavior: smooth;
   scroll-padding: 10px;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 #typora-sidebar {
@@ -1639,14 +1638,6 @@ body.typora-export {
 }
 #top-titlebar .btn {
   margin: 0 !important;
-}
-
-#top-titlebar {
-  height: auto;
-}
-
-.info-panel-tab-wrapper {
-  height: auto;
 }
 
 /* .megamenu-men */

--- a/mdmdt-light.css
+++ b/mdmdt-light.css
@@ -105,6 +105,7 @@ body content,
 body #write {
   scrollbar-color: var(--border-color) var(--bg-color2) !important;
   scrollbar-width: thin !important;
+  overflow-x: auto;
 }
 
 body,
@@ -1634,6 +1635,14 @@ body.typora-export {
 }
 #top-titlebar .btn {
   margin: 0 !important;
+}
+
+#top-titlebar {
+  height: auto;
+}
+
+.info-panel-tab-wrapper {
+  height: auto;
 }
 
 /* .megamenu-men */

--- a/mdmdt-light.css
+++ b/mdmdt-light.css
@@ -105,7 +105,6 @@ body content,
 body #write {
   scrollbar-color: var(--border-color) var(--bg-color2) !important;
   scrollbar-width: thin !important;
-  overflow-x: auto;
 }
 
 body,
@@ -857,7 +856,7 @@ span.md-comment {
   padding: 0 96px 32px;
   scroll-behavior: smooth;
   scroll-padding: 10px;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 #typora-sidebar {
@@ -1635,14 +1634,6 @@ body.typora-export {
 }
 #top-titlebar .btn {
   margin: 0 !important;
-}
-
-#top-titlebar {
-  height: auto;
-}
-
-.info-panel-tab-wrapper {
-  height: auto;
 }
 
 /* .megamenu-men */

--- a/mdmdt.css
+++ b/mdmdt.css
@@ -104,7 +104,6 @@ body content,
 body #write {
   scrollbar-color: var(--border-color) var(--bg-color2) !important;
   scrollbar-width: thin !important;
-  overflow-x: auto;
 }
 
 body,
@@ -858,7 +857,7 @@ span.md-comment {
   padding: 0 96px 32px;
   scroll-behavior: smooth;
   scroll-padding: 10px;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 #typora-sidebar {
@@ -1636,14 +1635,6 @@ body.typora-export {
 }
 #top-titlebar .btn {
   margin: 0 !important;
-}
-
-#top-titlebar {
-  height: auto;
-}
-
-.info-panel-tab-wrapper {
-  height: auto;
 }
 
 /* .megamenu-men */

--- a/mdmdt.css
+++ b/mdmdt.css
@@ -104,6 +104,7 @@ body content,
 body #write {
   scrollbar-color: var(--border-color) var(--bg-color2) !important;
   scrollbar-width: thin !important;
+  overflow-x: auto;
 }
 
 body,
@@ -1635,6 +1636,14 @@ body.typora-export {
 }
 #top-titlebar .btn {
   margin: 0 !important;
+}
+
+#top-titlebar {
+  height: auto;
+}
+
+.info-panel-tab-wrapper {
+  height: auto;
 }
 
 /* .megamenu-men */


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ce8179c3-582a-47fe-aadc-5ddec5f8a81a)

首先，我是修改了以下部分的CSS代码，发现可以解决图片中底部滚动条异常显示的问题

```css
body #write {
  scrollbar-color: var(--border-color) var(--bg-color2) !important;
  scrollbar-width: thin !important;
  overflow-x: auto;  /* 此处为增加内容 */
}
```

但是又出现了新的问题，侧边栏以及窗口右上角出现滚动条样式，请看下图
![image](https://github.com/user-attachments/assets/22e78803-53af-4015-b1d2-c620d4f24e18)

通过检查元素发现，可能是主题CSS与Typora自身的CSS样式有冲突，比如`#top-titlebar`选择器下Typora自身有个`height: 24px`的样式，改为`height: auto`，就能解决掉窗口右上角出现的滚动条。 同理，侧边栏右上角滚动条也可以通过`.info-panel-tab-wrapper`选择器使`height: auto`

```css
/*以下为增加内容*/
#top-titlebar {
  height: auto;
}

.info-panel-tab-wrapper {
  height: auto;
}
```

![image](https://github.com/user-attachments/assets/95e02db5-ed9f-404a-9ce8-c4d3e91d0fee)